### PR TITLE
Integrate OpenAI responses into Telegram worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # telegram-codex-test
 this is for codex course of sharifgpt
+
+## Setup
+
+Store required secrets in your Cloudflare worker, including the OpenAI API key:
+
+```
+wrangler secret put OPENAI_API_KEY
+```
+
+The worker will call OpenAI's Responses API and forward the result to users in Telegram.

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ export interface Env {
   BOT_KV: KVNamespace;
   BOT_TOKEN: string;
   WEBHOOK_SECRET: string;
+  OPENAI_API_KEY: string;
 }
 
 export default {
@@ -25,7 +26,33 @@ export default {
       const chatId: number | undefined = message?.chat?.id;
 
       if (text && chatId) {
-        const body = { chat_id: chatId, text };
+        let replyText = text;
+        try {
+          const aiResp = await fetch('https://api.openai.com/v1/responses', {
+            method: 'POST',
+            headers: {
+              'Authorization': `Bearer ${env.OPENAI_API_KEY}`,
+              'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+              model: 'gpt-5-mini',
+              input: text,
+              max_output_tokens: 800
+            })
+          });
+
+          const aiJson = await aiResp.json<Record<string, any>>();
+          replyText =
+            aiJson.output_text ??
+            aiJson.output?.map((o: any) =>
+              o.content?.map((c: any) => c.text).join('')
+            ).join('\n') ??
+            replyText;
+        } catch (err) {
+          console.error('OpenAI request failed', err);
+        }
+
+        const body = { chat_id: chatId, text: replyText };
         console.log('Sending message to Telegram:', body);
 
         const telegramResp = await fetch(


### PR DESCRIPTION
## Summary
- Add OPENAI_API_KEY secret and call OpenAI Responses API
- Forward generated responses back to Telegram users
- Document how to store the OpenAI API key as a Cloudflare secret
- Parse nested OpenAI response content before replying

## Testing
- `npm test`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68a707ea00308332b28e7997d3d072b7