### PR TITLE
feat: add basic command handling

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,66 @@ export interface Env {
   OPENAI_API_KEY: string;
 }
 
+interface UserSettings {
+  tone: 'formal' | 'friendly' | 'technical';
+  messagesToday: number;
+  lastDate: string;
+}
+
+const SETTINGS_PREFIX = 'settings:';
+
+async function getSettings(chatId: number, env: Env): Promise<UserSettings> {
+  const today = new Date().toISOString().slice(0, 10);
+  const stored = await env.BOT_KV.get<UserSettings>(`${SETTINGS_PREFIX}${chatId}`, {
+    type: 'json'
+  });
+  if (stored) {
+    if (stored.lastDate !== today) {
+      stored.messagesToday = 0;
+      stored.lastDate = today;
+      await saveSettings(chatId, env, stored);
+    }
+    return stored;
+  }
+  const defaults: UserSettings = {
+    tone: 'friendly',
+    messagesToday: 0,
+    lastDate: today
+  };
+  await saveSettings(chatId, env, defaults);
+  return defaults;
+}
+
+async function saveSettings(
+  chatId: number,
+  env: Env,
+  settings: UserSettings
+): Promise<void> {
+  await env.BOT_KV.put(
+    `${SETTINGS_PREFIX}${chatId}`,
+    JSON.stringify(settings)
+  );
+}
+
+async function sendTelegramMessage(
+  env: Env,
+  chatId: number,
+  text: string
+): Promise<void> {
+  const body = { chat_id: chatId, text };
+  console.log('Sending message to Telegram:', body);
+  const telegramResp = await fetch(
+    `https://api.telegram.org/bot${env.BOT_TOKEN}/sendMessage`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body)
+    }
+  );
+  const respText = await telegramResp.text();
+  console.log('Telegram response:', respText);
+}
+
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const url = new URL(request.url);
@@ -26,47 +86,98 @@ export default {
       const chatId: number | undefined = message?.chat?.id;
 
       if (text && chatId) {
-        let replyText = text;
-        try {
-          const aiResp = await fetch('https://api.openai.com/v1/responses', {
-            method: 'POST',
-            headers: {
-              'Authorization': `Bearer ${env.OPENAI_API_KEY}`,
-              'Content-Type': 'application/json'
-            },
-            body: JSON.stringify({
-              model: 'gpt-5-mini',
-              input: text,
-              max_output_tokens: 800
-            })
-          });
+        const [command, ...args] = text.trim().split(/\s+/);
+        const settings = await getSettings(chatId, env);
 
-          const aiJson = await aiResp.json<Record<string, any>>();
-          replyText =
-            aiJson.output_text ??
-            aiJson.output?.map((o: any) =>
-              o.content?.map((c: any) => c.text).join('')
-            ).join('\n') ??
-            replyText;
-
-        } catch (err) {
-          console.error('OpenAI request failed', err);
-        }
-
-        const body = { chat_id: chatId, text: replyText };
-        console.log('Sending message to Telegram:', body);
-
-        const telegramResp = await fetch(
-          `https://api.telegram.org/bot${env.BOT_TOKEN}/sendMessage`,
-          {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(body)
+        switch (command) {
+          case '/start':
+            await sendTelegramMessage(
+              env,
+              chatId,
+              'Welcome! I\'m your AI assistant powered by GPT-5 Pro. Ask me anything or try /help for more information.'
+            );
+            break;
+          case '/help':
+            await sendTelegramMessage(
+              env,
+              chatId,
+              'Available commands:\n/help - Show this message\n/settings - View current settings\n/settings_tone [formal|friendly|technical] - Change response style'
+            );
+            break;
+          case '/settings':
+            await sendTelegramMessage(
+              env,
+              chatId,
+              `Current settings:\nTone: ${settings.tone.charAt(0).toUpperCase() + settings.tone.slice(1)}\nModel: GPT-5 Pro\nMessages today: ${settings.messagesToday}/50`
+            );
+            break;
+          case '/settings_tone': {
+            const tone = args[0];
+            if (
+              tone === 'formal' ||
+              tone === 'friendly' ||
+              tone === 'technical'
+            ) {
+              settings.tone = tone;
+              await saveSettings(chatId, env, settings);
+              const toneMsg: Record<string, string> = {
+                formal: 'professional language.',
+                friendly: 'a friendly style.',
+                technical:
+                  'precise terminology and provide detailed explanations.'
+              };
+              await sendTelegramMessage(
+                env,
+                chatId,
+                `Tone changed to ${tone}. Responses will now use ${toneMsg[tone]}`
+              );
+            } else {
+              await sendTelegramMessage(
+                env,
+                chatId,
+                'Usage: /settings_tone [formal|friendly|technical]'
+              );
+            }
+            break;
           }
-        );
+          default: {
+            let replyText = text;
+            try {
+              const aiResp = await fetch('https://api.openai.com/v1/responses', {
+                method: 'POST',
+                headers: {
+                  Authorization: `Bearer ${env.OPENAI_API_KEY}`,
+                  'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({
+                  model: 'gpt-5-mini',
+                  input:
+                    settings.tone === 'friendly'
+                      ? text
+                      : `Respond in a ${settings.tone} tone. ${text}`,
+                  max_output_tokens: 800
+                })
+              });
 
-        const respText = await telegramResp.text();
-        console.log('Telegram response:', respText);
+              const aiJson = await aiResp.json<Record<string, any>>();
+              replyText =
+                aiJson.output_text ??
+                aiJson.output
+                  ?.map((o: any) =>
+                    o.content?.map((c: any) => c.text).join('')
+                  )
+                  .join('\n') ??
+                replyText;
+            } catch (err) {
+              console.error('OpenAI request failed', err);
+            }
+
+            settings.messagesToday += 1;
+            await saveSettings(chatId, env, settings);
+            await sendTelegramMessage(env, chatId, replyText);
+            break;
+          }
+        }
       } else {
         console.log('No message to echo:', update);
       }


### PR DESCRIPTION
## Summary
- handle /start, /help, /settings, and /settings_tone commands
- store tone and daily message count in KV
- apply tone to OpenAI responses and track usage

## Testing
- `npm test`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68a70d239e40833282841845a2657c1d