### PR TITLE
Add basic command handling and user settings

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,30 +26,89 @@ export default {
       const chatId: number | undefined = message?.chat?.id;
 
       if (text && chatId) {
-        // Build a per-user, per-day quota key
+        // Build per-user keys
         const now = new Date();
         const date = now.toISOString().slice(0, 10).replace(/-/g, '');
         const quotaKey = `quota:user:${chatId}:${date}`;
+        const settingsKey = `settings:user:${chatId}`;
 
-        // Fetch existing usage from KV, defaulting to zero
+        // Fetch usage and settings
         const usage = await env.BOT_KV.get(quotaKey, { type: 'json' }) as
           | { count: number; tokens: number }
           | null;
+        const settings = await env.BOT_KV.get(settingsKey, { type: 'json' }) as
+          | { tone: 'friendly' | 'formal' | 'technical' }
+          | null;
+
         let count = usage?.count ?? 0;
         let tokens = usage?.tokens ?? 0;
+        let tone: 'friendly' | 'formal' | 'technical' =
+          settings?.tone ?? 'friendly';
 
-        // Enforce daily limit of 20 calls or 20k tokens
-        if (count >= 20 || tokens >= 20000) {
+        const send = async (text: string) => {
           await fetch(`https://api.telegram.org/bot${env.BOT_TOKEN}/sendMessage`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              chat_id: chatId,
-              text: 'Daily quota exceeded. Please try again tomorrow.'
-            })
+            body: JSON.stringify({ chat_id: chatId, text })
           });
+        };
+
+        const lower = text.toLowerCase();
+
+        if (lower.startsWith('/start')) {
+          await send(
+            "Welcome! I'm your AI assistant powered by GPT-5 Pro. Ask me anything or try /help for more information."
+          );
           return new Response('ok');
         }
+
+        if (lower.startsWith('/help')) {
+          await send(
+            'Available commands:\n/help - Show this message\n/settings - View current settings\n/settings_tone [formal|friendly|technical] - Change response style'
+          );
+          return new Response('ok');
+        }
+
+        if (lower.startsWith('/settings_tone')) {
+          const parts = text.split(/\s+/);
+          const newTone = parts[1]?.toLowerCase();
+          const valid = ['formal', 'friendly', 'technical'] as const;
+          if (newTone && (valid as readonly string[]).includes(newTone)) {
+            tone = newTone as typeof valid[number];
+            await env.BOT_KV.put(settingsKey, JSON.stringify({ tone }));
+            const toneMessages: Record<typeof valid[number], string> = {
+              friendly:
+                'Tone changed to friendly. Responses will maintain a warm and conversational style.',
+              formal:
+                'Tone changed to formal. Responses will follow professional and courteous language.',
+              technical:
+                'Tone changed to technical. Responses will now use precise terminology and provide detailed explanations.'
+            };
+            await send(toneMessages[tone]);
+          } else {
+            await send(
+              'Usage: /settings_tone [formal|friendly|technical]'
+            );
+          }
+          return new Response('ok');
+        }
+
+        if (lower.startsWith('/settings')) {
+          const toneLabel = tone.charAt(0).toUpperCase() + tone.slice(1);
+          await send(
+            `Current settings:\nTone: ${toneLabel}\nModel: GPT-5 Pro\nMessages today: ${count}/50`
+          );
+          return new Response('ok');
+        }
+
+        // Enforce daily limit of 50 calls or 20k tokens
+        if (count >= 50 || tokens >= 20000) {
+          await send('Daily quota exceeded. Please try again tomorrow.');
+          return new Response('ok');
+        }
+
+        // Adjust input for tone
+        const prompt = `Respond in a ${tone} tone. ${text}`;
 
         let replyText = text;
         let totalTokens = 0;
@@ -61,8 +120,8 @@ export default {
               'Content-Type': 'application/json'
             },
             body: JSON.stringify({
-              model: 'gpt-5-mini',
-              input: text,
+              model: 'gpt-5-pro',
+              input: prompt,
               max_output_tokens: 800
             })
           });
@@ -92,20 +151,7 @@ export default {
           { expirationTtl: 60 * 60 * 48 }
         );
 
-        const body = { chat_id: chatId, text: replyText };
-        console.log('Sending message to Telegram:', body);
-
-        const telegramResp = await fetch(
-          `https://api.telegram.org/bot${env.BOT_TOKEN}/sendMessage`,
-          {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(body)
-          }
-        );
-
-        const respText = await telegramResp.text();
-        console.log('Telegram response:', respText);
+        await send(replyText);
       } else {
         console.log('No message to echo:', update);
       }


### PR DESCRIPTION
## Summary
- Handle /start, /help, /settings, and /settings_tone commands
- Persist user tone preferences and expose current settings
- Enforce 50 message daily limit and apply tone when calling GPT-5 Pro

## Testing
- `npm test`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68a70e62f6908332bb50680f375c9fe9